### PR TITLE
Bug fix on errorTextParent selector

### DIFF
--- a/src/pristine.js
+++ b/src/pristine.js
@@ -206,7 +206,7 @@ export default function Pristine(form, config, live){
         if (self.config.classTo === self.config.errorTextParent){
             errorTextParent = errorClassElement;
         } else {
-            errorTextParent = errorClassElement.querySelector(self.errorTextParent);
+            errorTextParent = errorClassElement.querySelector('.' + self.config.errorTextParent);
         }
         if (errorTextParent){
             errorTextElement = errorTextParent.querySelector('.' + PRISTINE_ERROR);


### PR DESCRIPTION
If the errorTextParent was a different element from classTo, the error messages were not being added to the DOM.