### PR TITLE
Support for dynamic error messages

### DIFF
--- a/src/pristine.js
+++ b/src/pristine.js
@@ -1,5 +1,5 @@
 import { lang } from './lang';
-import { tmpl, findAncestor, groupedElemCount, mergeConfig } from './utils';
+import { tmpl, findAncestor, groupedElemCount, mergeConfig, isFunction } from './utils';
 
 let defaultConfig = {
     classTo: 'form-group',
@@ -162,8 +162,14 @@ export default function Pristine(form, config, live){
             params[0] = field.input.value;
             if (!validator.fn.apply(field.input, params)){
                 valid = false;
-                let error = field.messages[validator.name] || validator.msg;
-                errors.push(tmpl.apply(error, params));
+
+                if (isFunction(validator.msg)) {
+                    errors.push(validator.msg(field.input.value, params))
+                } else {
+                    let error = field.messages[validator.name] || validator.msg;
+                    errors.push(tmpl.apply(error, params));
+                }
+
                 if (validator.halt === true){
                     break;
                 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -19,3 +19,7 @@ export function mergeConfig(obj1, obj2) {
     }
     return obj1;
 }
+
+export function isFunction(obj) {
+    return !!(obj && obj.constructor && obj.call && obj.apply);
+}


### PR DESCRIPTION
My change introduces support for dynamic error messages.

![dynamic-error-msg](https://user-images.githubusercontent.com/6187417/71977195-77478080-3218-11ea-99a1-c5f0d7d383fb.gif)

As described in README, currently Pristine supports static messages via:
```js
pristine.addValidator(elem, function(value) {
    // here `this` refers to the respective input element
    if (value.length && value[0] === value[0].toUpperCase()){
        return true;
    }
    return false;
}, "The first character must be capitalized", 2, false);
```
My change gives you the possibility to declare message as a function, that - in case of validation error - would once again obtain field value to format error message.

```js
pristine.addValidator(
elem, (value) => {
    // here `this` refers to the respective input element
    if (value.length && value[0] === value[0].toUpperCase()){
        return true;
    }
    return false;
}, (value) => `You cannot enter ${value} in this field` , 2, false);
```

There's pretty wide range of use-cases for this update. For example, our internal validators support both `isValid` and `mismatch` functions, and we always try to display characters that are invalid next to error message. It could work in this way:

```js
validatedForm.addValidator(
        document.querySelector('#first-name'),
        (value) => PersonNameValidator.validate(value),
        (value) => {
            const mismatch = PersonNameValidator.getMismatch(value).person_name
            return `Incorrect characters - ${mismatch}`
        },
        1, false
    )
```

@sha256 How do you feel about this suggestion?