### PR TITLE
Fix getErrors issue when field has not error

### DIFF
--- a/src/pristine.js
+++ b/src/pristine.js
@@ -141,7 +141,7 @@ export default function Pristine(form, config, live){
             let erroneousFields = [];
             for(let i=0; i<self.fields.length; i++){
                 let field = self.fields[i];
-                if (field.errors.length){
+                if (field.errors && field.errors.length){
                     erroneousFields.push({input: field.input, errors: field.errors});
                 }
             }


### PR DESCRIPTION
Maybe I am missing something, but if I try to get all errors for all input, sometime field has not property `errors`.

Before checking `field.errors.length` I add a check if field.errors is set.

Otherwise there is an error in console.