### PR TITLE
Update pristine.js

### DIFF
--- a/src/pristine.js
+++ b/src/pristine.js
@@ -121,7 +121,7 @@ export default function Pristine(form, config, live){
 
         for(let i = 0; fields[i]; i++) {
             let field = fields[i];
-            if (_validateField(field)){
+            if (typeof field === 'object' && _validateField(field)){
                 !silent && _showSuccess(field);
             } else {
                 valid = false;


### PR DESCRIPTION
It can be helpful to vheck field type to avoid type errors. 
A see many times in my js log: "TypeError: undefined is not an object (evaluating 'field.validators')"